### PR TITLE
Double quotes to single qoutes.

### DIFF
--- a/examples/breakout.py
+++ b/examples/breakout.py
@@ -1,4 +1,4 @@
-"""
+'''
  Sample Breakout Game
  
  Adapted to PsychoPy from:
@@ -6,7 +6,7 @@
  Simpson College Computer Science
  http://programarcadegames.com/
  http://simpson.edu/computer-science/
-"""
+'''
  
 # --- Import libraries used for this program
  
@@ -124,12 +124,12 @@ def generate_blocks():
  
  
 class Block():
-    """This class represents each block that will get knocked out by the ball
-    """
+    '''This class represents each block that will get knocked out by the ball
+    '''
  
     def __init__(self, color, x, y):
-        """ Constructor. Pass in the color of the block,
-            and its x and y position. """
+        ''' Constructor. Pass in the color of the block,
+            and its x and y position. '''
 
         # Create the image of the block of appropriate size
         # The width and height are sent as a list for the first parameter.
@@ -143,8 +143,8 @@ class Block():
   
  
 class Ball():
-    """ This class represents the ball
-    """
+    ''' This class represents the ball
+    '''
  
     # Constructor. Pass in the color of the block, and its x and y position
     def __init__(self):
@@ -170,14 +170,14 @@ class Ball():
 #        
   
     def bounce(self, diff):
-        """ This function will bounce the ball
-            off a horizontal surface (not a vertical one) """
+        ''' This function will bounce the ball
+            off a horizontal surface (not a vertical one) '''
  
         self.direction = (180 - self.direction) % 360
         self.direction += diff
  
     def update(self):
-        """ Update the position of the ball. """
+        ''' Update the position of the ball. '''
         
         # Sine and Cosine work in degrees, so we have to convert them
         direction_radians = math.radians(self.direction)
@@ -210,11 +210,11 @@ class Ball():
             return False
  
 class Player():
-    """ This class represents the bar at the bottom that the
-    player controls. """
+    ''' This class represents the bar at the bottom that the
+    player controls. '''
  
     def __init__(self):
-        """ Constructor for Player. """
+        ''' Constructor for Player. '''
  
         self.width = 300
         self.height =15
@@ -228,7 +228,7 @@ class Player():
         
   
     def update(self):
-        """ Update the player position. """
+        ''' Update the player position. '''
         
         if eye_tracking:
             

--- a/examples/read_me.py
+++ b/examples/read_me.py
@@ -92,7 +92,7 @@ tracker.start_recording()
 core.wait(0.1)
 
 # Flip an image onto the screen here
-tracker.set_begaze_trial_image("imname.png")
+tracker.set_begaze_trial_image('imname.png')
 core.wait(1)
 tracker.stop_recording()
 

--- a/py_smite/HiSpeed.py
+++ b/py_smite/HiSpeed.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-"""
+'''
 Created on Sat Jan 09 19:50:57 2016
 
 @author: marcus
@@ -8,7 +8,7 @@ Settings file for the HiSpeed1250 eye tracker
 Here we list parameters that can be sent remotely to iView X to override default parameters
 OBS! PsychoPy geometric setup should match that entered in iView
 
-"""
+'''
 
 
 MY_MONITOR                  = 'default' # needs to exists in PsychoPy monitor center
@@ -28,7 +28,7 @@ average_data = False
 filtering = False # You need to turn off the 'bilateral' filter manually
 
 #%% Files and filepaths
-temp_folder_path = r"C:\\ProgramData\SMI\iViewX\temp"
+temp_folder_path = r'C:\\ProgramData\SMI\iViewX\temp'
 delete_temp_idf_files = False
 
 eye_image_size = (160, 640)# Size of eye images in HiSpeed 1250

--- a/py_smite/RED.py
+++ b/py_smite/RED.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-"""
+'''
 Created on Sat Jan 09 19:50:57 2016
 
 @author: marcus
@@ -8,7 +8,7 @@ Settings file for the RED250/500 eye tracker
 Here we list parameters that can be sent remotely to iView X to override default parameters
 OBS! PsychoPy geometric setup should match that entered in iView
 
-"""
+'''
 
 
 MY_MONITOR                  = 'default' # needs to exists in PsychoPy monitor center
@@ -28,7 +28,7 @@ average_data = False
 filtering = False # Use filters 
 
 #%% Files and filepaths
-temp_folder_path = r"C:\\ProgramData\SMI\iViewX\temp"
+temp_folder_path = r'C:\\ProgramData\SMI\iViewX\temp'
 delete_temp_idf_files = False
 
 eye_image_size = (80, 344)# Size of eye images in RED

--- a/py_smite/RED250mobile.py
+++ b/py_smite/RED250mobile.py
@@ -1,12 +1,12 @@
 # -*- coding: utf-8 -*-
-"""
+'''
 Created on Sat Jan 09 19:50:57 2016
 
 @author: marcus
 
 Settings file for the REDm Professional eye tracker
 
-"""
+'''
 
 MY_MONITOR = 'default'              # needs to exist in PsychoPy monitor center
 

--- a/py_smite/REDm.py
+++ b/py_smite/REDm.py
@@ -1,11 +1,11 @@
 # -*- coding: utf-8 -*-
-"""
+'''
 Created on Sat Jan 09 19:50:57 2016
 
 @author: marcus
 
 Settings file for the RED-m eye tracker
-"""
+'''
 
 MY_MONITOR = 'default'              # needs to exist in PsychoPy monitor center
 

--- a/py_smite/REDn_Professional.py
+++ b/py_smite/REDn_Professional.py
@@ -1,12 +1,12 @@
 # -*- coding: utf-8 -*-
-"""
+'''
 Created on Sat Jan 09 19:50:57 2016
 
 @author: marcus
 
 Settings file for the REDm Professional eye tracker
 
-"""
+'''
 
 MY_MONITOR = 'default'              # needs to exist in PsychoPy monitor center
 

--- a/py_smite/REDn_Scientific.py
+++ b/py_smite/REDn_Scientific.py
@@ -1,12 +1,12 @@
 # -*- coding: utf-8 -*-
-"""
+'''
 Created on Sat Jan 09 19:50:57 2016
 
 @author: marcus
 
 Settings file for the REDm Professional eye tracker
 
-"""
+'''
 
 MY_MONITOR = 'default'              # needs to exist in PsychoPy monitor center
 

--- a/py_smite/SMITE.py
+++ b/py_smite/SMITE.py
@@ -1,9 +1,9 @@
 # -*- coding: utf-8 -*-
-"""
+'''
 Created on Mon Feb 26 14:16:59 2018
 
 @author: Marcus
-"""
+'''
 
 from psychopy import core
 

--- a/py_smite/SMITE_Dummy.py
+++ b/py_smite/SMITE_Dummy.py
@@ -7,9 +7,9 @@ import numpy as np
 import SMITE_Dummy_raw
         
 class Connect(object):
-    """
+    '''
     Creates a class that simplifies life for people wanting to use the SDK
-    """
+    '''
     def __init__(self):
 
         self.rawSMI = SMITE_Dummy_raw.Connect()
@@ -86,9 +86,9 @@ class Connect(object):
     def stop_recording(self):
         self.rawSMI.stop_recording()
     #%% 
-    def save_data(self, filename, description = "", 
+    def save_data(self, filename, description = '', 
                    user = None, overwrite=0):
-        self.rawSMI.save_data(filename, description = "", 
+        self.rawSMI.save_data(filename, description = '', 
                    user = None, overwrite=0)        
     #%%
     def de_init(self):

--- a/py_smite/SMITE_Dummy_raw.py
+++ b/py_smite/SMITE_Dummy_raw.py
@@ -39,9 +39,9 @@ class Eye:
 #%%    
         
 class Connect(Thread):
-    """
+    '''
     Basic functionally to communicate with and manage SMI eye trackers
-    """
+    '''
     def __init__(self):
         '''
         Constructs an instance of the SMITE interface, with specified settings. 
@@ -731,7 +731,7 @@ class Connect(Thread):
         print('save_calibration')        
         
     #%%             
-    def save_data(self, filename, description = "", 
+    def save_data(self, filename, description = '', 
                    user = None, overwrite=0):
         ''' Writes recorded data buffer to disc. 
         The data recording needs to be stopped using iV_StopRecording
@@ -762,8 +762,8 @@ class Connect(Thread):
             
         # Split filename into path and filename
         path, filename = os.path.split(filename)
-        assert(len(path) > 0), "Filename must have a path"
-        assert(len(filename) > 0), "Filename must be given"
+        assert(len(path) > 0), 'Filename must have a path'
+        assert(len(filename) > 0), 'Filename must be given'
 
         # Check if a '.idf was added to the filename. If so, remove it
         ext = os.path.splitext(filename)[1]
@@ -793,8 +793,8 @@ class Connect(Thread):
     #%%             
     def send_image_message(self, msg):
         ''' Sends a text message to iView X idf recording data file. 
-        If the etMessage has the suffix ".jpg", ".bmp",
-        ".png", or ".avi" BeGaze will separate the data buffer 
+        If the etMessage has the suffix '.jpg', '.bmp',
+        '.png', or '.avi' BeGaze will separate the data buffer 
         automatically into according trials.
         
         Supported systems: all 
@@ -922,7 +922,7 @@ class Connect(Thread):
         if self.set_sampling_freq_allowed:
             print('set_speed_mode')   
         else:
-            print("WARNING: set_speed_mode is not supported on this eye tracker")
+            print('WARNING: set_speed_mode is not supported on this eye tracker')
             
     #%%     
     def set_tracking_mode(self, mode):
@@ -954,7 +954,7 @@ class Connect(Thread):
             
             print('set_tracking_mode')  
         else:
-            print("WARNING: set_tracking_mode is not supported on this eye tracker")          
+            print('WARNING: set_tracking_mode is not supported on this eye tracker')          
             
     #%%
     def set_tracking_monitor_callback(self, function_name):
@@ -996,7 +996,7 @@ class Connect(Thread):
                                      target_size=20, 
                                      target_shape=2): 
                                                             
-        """
+        '''
         Sets the calibration and validation visualization parameter.
         
         Setup calibration parameters (but do not initiate calibration)
@@ -1016,7 +1016,7 @@ class Connect(Thread):
         Supported systems: all 
         
         
-        """
+        '''
         
         print('setup_calibration_parameters')     
         
@@ -1143,10 +1143,10 @@ class Connect(Thread):
  
     #%%             
     def set_cal_positions(self, cal_positions):
-        """
+        '''
         Sets the positions of the calibration locations
         cal_positions is a dict:  {1:[x,y],2:[x,y],....}
-        """
+        '''
         if cal_positions:
             for k in cal_positions.keys():
                 self.change_calibration_point(k, cal_positions[k][0], cal_positions[k][1])    
@@ -1167,7 +1167,7 @@ class Connect(Thread):
         ext = os.path.splitext(imname)[1]
         
         # check extention is one of the supported ones
-        assert(len([i for i in ['.png','.jpg','.jpeg','.bmp','.avi'] if ext == i]) > 0), "Filename not supported"
+        assert(len([i for i in ['.png','.jpg','.jpeg','.bmp','.avi'] if ext == i]) > 0), 'Filename not supported'
         self.send_image_message(imname)
         
     #%% 
@@ -1189,17 +1189,17 @@ class Connect(Thread):
     #%%     
     def start_eye_image_recording(self, image_name, path):
         ''' Starts eye image recording
-        Example: start_eye_image_recording('test',"c:\\eyeimages\\" )
+        Example: start_eye_image_recording('test','c:\\eyeimages\\' )
         '''
         
-        self.send_command(' '.join(["ET_EVB 1", image_name, path]))
+        self.send_command(' '.join(['ET_EVB 1', image_name, path]))
 
             
     #%%             
     def stop_eye_image_recording(self):
         ''' Stops eye image recording
         '''
-        self.send_command("ET_EVE")
+        self.send_command('ET_EVE')
                
      
     #%%
@@ -1240,7 +1240,7 @@ class Connect(Thread):
     def increment_trial_number(self):
         ''' Increments trial number in iview X buffer.
         '''
-        self.send_command("ET_INC")
+        self.send_command('ET_INC')
 
     
     #%%  

--- a/py_smite/SMITE_ET.py
+++ b/py_smite/SMITE_ET.py
@@ -18,8 +18,8 @@ import SMITE_raw
 global buf
       
 class Connect(object):
-    """ Create a class that simplifies life for people wanting to use the SDK
-    """
+    ''' Create a class that simplifies life for people wanting to use the SDK
+    '''
     def __init__(self, in_arg):
         '''
         Args:
@@ -170,7 +170,7 @@ class Connect(object):
                 
                 # Write the calibration results to the idf file
                 self.start_recording()
-                self.send_message("Calibration results in degrees (LX, LY, RX, RY): {}".format([d for d in devs]))
+                self.send_message('Calibration results in degrees (LX, LY, RX, RY): {}'.format([d for d in devs]))
                 self.stop_recording()
                 
             else:
@@ -260,7 +260,7 @@ class Connect(object):
         
         
     #%% 
-    def save_data(self, filename, description = "", 
+    def save_data(self, filename, description = '', 
                    user = None, append_version=True):
         ''' Save idf file to specified location
         The data recording needs to be stopped using iV_StopRecording
@@ -330,7 +330,7 @@ class Connect(object):
             image_name - filename where recorded eye images will be saved
             path - path where the eye images are stored
             
-        Example: start_eye_image_recording('test',"c:\\eyeimages\\" )
+        Example: start_eye_image_recording('test','c:\\eyeimages\\' )
         '''
         self.rawSMI.start_eye_image_recording(image_name, path)
     #%%
@@ -571,7 +571,7 @@ class Connect(object):
     #%%        
     def _run_calibration(self, deviations, show_instructions=False,
                    select_best_calibration=False, optional=False):
-        """ Run the calibration
+        ''' Run the calibration
         
         Args: 
             deviations - list containing results from previous calibrations
@@ -580,7 +580,7 @@ class Connect(object):
                                         calibrations
             optional - is the calibration optional or required (allows you to 
                        skip the calibration if set to True).
-        """
+        '''
                 
         self.win.flip()
         self.instruction_text.pos = (0, 0)
@@ -1145,7 +1145,7 @@ class Connect(object):
 
 #%%   
 class AnimatedCalibrationDisplay(object):
-    """ A class for drawing animated targets"""
+    ''' A class for drawing animated targets'''
     def __init__(self, win, target, function_name):
         ''' The function 'function_name' does the actual drawing
         '''

--- a/py_smite/SMITE_raw.py
+++ b/py_smite/SMITE_raw.py
@@ -28,8 +28,8 @@ tracking_mode_dict = {'SMART_BINOCULAR':0, 'MONOCULAR_LEFT':1,
 #%%    
         
 class Connect(object):
-    """ Basic functionally to communicate with and manage SMI eye trackers
-    """
+    ''' Basic functionally to communicate with and manage SMI eye trackers
+    '''
     def __init__(self, in_arg):
         '''
         Constructs an instance of the SMITE interface, with specified settings. 
@@ -1080,7 +1080,7 @@ class Connect(object):
         HandleError(res)      
         
     #%%             
-    def save_data(self, filename, description = "", 
+    def save_data(self, filename, description = '', 
                    user = None, append_version=True):
         ''' Writes recorded data buffer to disc. 
         The data recording needs to be stopped using iV_StopRecording
@@ -1109,8 +1109,8 @@ class Connect(object):
             
         # Split filename into path and filename
         path, filename = os.path.split(filename)
-        assert(len(path) > 0), "Filename must have a path"
-        assert(len(filename) > 0), "Filename must be given"
+        assert(len(path) > 0), 'Filename must have a path'
+        assert(len(filename) > 0), 'Filename must be given'
 
         # Check if a '.idf was added to the filename. If so, remove it
         ext = os.path.splitext(filename)[1]
@@ -1178,7 +1178,7 @@ class Connect(object):
         print(profile)
         res = iViewXAPI.iV_SelectREDGeometry(c_char_p(profile.encode('ascii')))
         HandleError(res)   
-        assert(res==1), "RED geometry profile does not exist"
+        assert(res==1), 'RED geometry profile does not exist'
         
         
     #%%
@@ -1194,8 +1194,8 @@ class Connect(object):
     #%%             
     def send_image_message(self, msg):
         ''' Sends a text message to iView X idf recording data file. 
-        If the etMessage has the suffix ".jpg", ".bmp",
-        ".png", or ".avi" BeGaze will separate the data buffer 
+        If the etMessage has the suffix '.jpg', '.bmp',
+        '.png', or '.avi' BeGaze will separate the data buffer 
         automatically into according trials.
         
         Supported systems: all 
@@ -1386,7 +1386,7 @@ class Connect(object):
             res = iViewXAPI.iV_SetSpeedMode(c_int(samplingrate))
             HandleError(res) 
         else:
-            print("WARNING: set_speed_mode is not supported on this eye tracker")
+            print('WARNING: set_speed_mode is not supported on this eye tracker')
             
     #%%     
     def set_tracking_mode(self, mode):
@@ -1419,7 +1419,7 @@ class Connect(object):
             res = iViewXAPI.iV_SetTrackingMode(tracking_mode_dict[mode])
             HandleError(res)
         else:
-            print("WARNING: set_tracking_mode is not supported on this eye tracker")          
+            print('WARNING: set_tracking_mode is not supported on this eye tracker')          
             
     #%%
     def set_tracking_monitor_callback(self, function_name):
@@ -1465,7 +1465,7 @@ class Connect(object):
                                      target_size=20, 
                                      target_shape=2): 
                                                             
-        """
+        '''
         Sets the calibration and validation visualization parameter.
         
         Setup calibration parameters (but do not initiate calibration)
@@ -1485,7 +1485,7 @@ class Connect(object):
         Supported systems: all 
         
         
-        """
+        '''
         
         calibrationData = CCalibration(cal_method,
                                        0, # Always use Psychopy for visualization
@@ -1496,7 +1496,7 @@ class Connect(object):
                                        bg_color,
                                        target_shape,
                                        target_size,
-                                       b"")
+                                       b'')
         res = iViewXAPI.iV_SetupCalibration(byref(calibrationData))
         print('CCdata {}'.format(res))
         HandleError(res)        
@@ -1636,10 +1636,10 @@ class Connect(object):
  
     #%%             
     def set_cal_positions(self, cal_positions):
-        """
+        '''
         Sets the positions of the calibration locations
         cal_positions is a dict:  {1:[x,y],2:[x,y],....}
-        """
+        '''
         if cal_positions:
             for k in cal_positions.keys():
                 self.change_calibration_point(k, cal_positions[k][0], cal_positions[k][1])    
@@ -1660,7 +1660,7 @@ class Connect(object):
         ext = os.path.splitext(imname)[1]
         
         # check extention is one of the supported ones
-        assert(len([i for i in ['.png','.jpg','.jpeg','.bmp','.avi'] if ext == i]) > 0), "Filename not supported"
+        assert(len([i for i in ['.png','.jpg','.jpeg','.bmp','.avi'] if ext == i]) > 0), 'Filename not supported'
         self.send_image_message(imname)
         
     #%% 
@@ -1682,24 +1682,24 @@ class Connect(object):
     #%%     
     def start_eye_image_recording(self, image_name, path):
         ''' Starts eye image recording
-        Example: start_eye_image_recording('test',"c:\\eyeimages\\" )
+        Example: start_eye_image_recording('test','c:\\eyeimages\\' )
         '''
         
-        self.send_command(' '.join(["ET_EVB 1", image_name, path]))
+        self.send_command(' '.join(['ET_EVB 1', image_name, path]))
 
             
     #%%             
     def stop_eye_image_recording(self):
         ''' Stops eye image recording
         '''
-        self.send_command("ET_EVE")
+        self.send_command('ET_EVE')
                
      
     #%%             
     def get_latest_sample(self):
         ''' Gets most recent gaze sample
         '''
-        #pickle.dump(self.get_sample(), open( "sample.p", "wb" ) )
+        #pickle.dump(self.get_sample(), open( 'sample.p', 'wb' ) )
         
         return self.get_sample()
         
@@ -1714,7 +1714,7 @@ class Connect(object):
     def increment_trial_number(self):
         ''' Increments trial number in iview X buffer.
         '''
-        self.send_command("ET_INC")
+        self.send_command('ET_INC')
 
     
     #%%  

--- a/py_smite/calibration_graphics.py
+++ b/py_smite/calibration_graphics.py
@@ -1,9 +1,9 @@
 # -*- coding: utf-8 -*-
-"""
+'''
 Created on Thu Aug 30 10:19:10 2018
 
 @author: Marcus
-"""
+'''
 import numpy as np
 
 blue = tuple(np.array([37, 97, 163]) / 255.0 * 2 - 1)

--- a/py_smite/helpers.py
+++ b/py_smite/helpers.py
@@ -1,9 +1,9 @@
 # -*- coding: utf-8 -*-
-"""
+'''
 Created on Fri Nov 10 21:31:13 2017
 
 @author: marcus
-"""
+'''
 
 from psychopy import visual
 import numpy as np
@@ -222,26 +222,26 @@ def psychopy2smi(pos, mon, units='norm'):
 
 #%%         
 class RingBuffer(object):
-    """ A simple ring buffer based on the deque class
-    Used as online buffer of gaze samples"""
+    ''' A simple ring buffer based on the deque class
+    Used as online buffer of gaze samples'''
     def __init__(self, maxlen=200):        
         # Create que with maxlen 
         self.maxlen = maxlen
         self._b = deque(maxlen=maxlen)  
 
     def clear(self):
-        """ Clears buffer """
+        ''' Clears buffer '''
         return(self._b.clear())
         
     def get_all(self):
-        """ Returns all samples from buffer and empties the buffer"""
+        ''' Returns all samples from buffer and empties the buffer'''
         lenb = len(self._b)
         return([self._b.popleft() for i in range(lenb)])
         
     def peek(self):
-        """ Returns all samples from buffer without emptying the buffer
+        ''' Returns all samples from buffer without emptying the buffer
         First remove an element, then add it again
-        """
+        '''
         b_temp = copy.copy(self._b)
         c = []
         if len(b_temp) > 0:
@@ -252,4 +252,4 @@ class RingBuffer(object):
         
     def append(self, L):
         self._b.append(L)         
-        """"Append buffer with the most recent sample (list L)"""
+        '''Append buffer with the most recent sample (list L)'''

--- a/py_smite/iViewXAPI.py
+++ b/py_smite/iViewXAPI.py
@@ -45,95 +45,95 @@ import platform
 #===========================
 
 class CSystem(Structure):
-	_fields_ = [("samplerate", c_int),
-	("iV_MajorVersion", c_int),
-	("iV_MinorVersion", c_int),
-	("iV_Buildnumber", c_int),
-	("API_MajorVersion", c_int),
-	("API_MinorVersion", c_int),
-	("API_Buildnumber", c_int),
-	("iV_ETDevice", c_int)]
+	_fields_ = [('samplerate', c_int),
+	('iV_MajorVersion', c_int),
+	('iV_MinorVersion', c_int),
+	('iV_Buildnumber', c_int),
+	('API_MajorVersion', c_int),
+	('API_MinorVersion', c_int),
+	('API_Buildnumber', c_int),
+	('iV_ETDevice', c_int)]
 
 class CCalibration(Structure):
-	_fields_ = [("method", c_int),
-	("visualization", c_int),
-	("displayDevice", c_int),
-	("speed", c_int),
-	("autoAccept", c_int),
-	("foregroundBrightness", c_int),
-	("backgroundBrightness", c_int),
-	("targetShape", c_int),
-	("targetSize", c_int),
-	("targetFilename", c_char * 256)]
+	_fields_ = [('method', c_int),
+	('visualization', c_int),
+	('displayDevice', c_int),
+	('speed', c_int),
+	('autoAccept', c_int),
+	('foregroundBrightness', c_int),
+	('backgroundBrightness', c_int),
+	('targetShape', c_int),
+	('targetSize', c_int),
+	('targetFilename', c_char * 256)]
 
 class CEye(Structure):
-	_fields_ = [("gazeX", c_double),
-	("gazeY", c_double),
-	("diam", c_double),
-	("eyePositionX", c_double),
-	("eyePositionY", c_double),
-	("eyePositionZ", c_double)]
+	_fields_ = [('gazeX', c_double),
+	('gazeY', c_double),
+	('diam', c_double),
+	('eyePositionX', c_double),
+	('eyePositionY', c_double),
+	('eyePositionZ', c_double)]
 
 class CSample(Structure):
-	_fields_ = [("timestamp", c_longlong),
-	("leftEye", CEye),
-	("rightEye", CEye),
-	("planeNumber", c_int)]
+	_fields_ = [('timestamp', c_longlong),
+	('leftEye', CEye),
+	('rightEye', CEye),
+	('planeNumber', c_int)]
 
 class CEvent(Structure):
-	_fields_ = [("eventType", c_char),
-	("eye", c_char),
-	("startTime", c_longlong),
-	("endTime", c_longlong),
-	("duration", c_longlong),
-	("positionX", c_double),
-	("positionY", c_double)]
+	_fields_ = [('eventType', c_char),
+	('eye', c_char),
+	('startTime', c_longlong),
+	('endTime', c_longlong),
+	('duration', c_longlong),
+	('positionX', c_double),
+	('positionY', c_double)]
 
 class CAccuracy(Structure):
-	_fields_ = [("deviationLX",c_double),
-				("deviationLY",c_double),
-				("deviationRX",c_double),
-				("deviationRY",c_double)]
+	_fields_ = [('deviationLX',c_double),
+				('deviationLY',c_double),
+				('deviationRX',c_double),
+				('deviationRY',c_double)]
     
 class CImage(Structure):
-	_fields_ = [("imageHeight",c_int),
-				("imageWidth",c_int),
-				("imageSize",c_int),
-				("imageBuffer", POINTER(c_char))]
+	_fields_ = [('imageHeight',c_int),
+				('imageWidth',c_int),
+				('imageSize',c_int),
+				('imageBuffer', POINTER(c_char))]
 				
     
 class CCalibrationPoint(Structure):
-    _fields_ = [("number",c_int),
-                ("positionX",c_int),
-                ("positionY",c_int)]
+    _fields_ = [('number',c_int),
+                ('positionX',c_int),
+                ('positionY',c_int)]
                 
 class CEyePosition(Structure):
-    _fields_ = [("validity",c_int),
-                ("relativePositionX",c_double),  
-                ("relativePositionY",c_double),
-                ("relativePositionZ",c_double),
-                ("positionRatingX",c_double),  
-                ("positionRatingY",c_double),
-                ("positionRatingZ",c_double)]
+    _fields_ = [('validity',c_int),
+                ('relativePositionX',c_double),  
+                ('relativePositionY',c_double),
+                ('relativePositionZ',c_double),
+                ('positionRatingX',c_double),  
+                ('positionRatingY',c_double),
+                ('positionRatingZ',c_double)]
 
 class CTrackingStatus(Structure):
-    _fields_ = [("timestamp", c_longlong),
-                ("leftEye", CEyePosition),
-                ("rightEye", CEyePosition),
-                ("total", CEyePosition)]
+    _fields_ = [('timestamp', c_longlong),
+                ('leftEye', CEyePosition),
+                ('rightEye', CEyePosition),
+                ('total', CEyePosition)]
 
 class CREDGeometry(Structure):
-    _fields_ = [("redGeometry", c_int),
-                ("monitorSize", c_int),
-                ("setupName", c_char * 256),
-                ("stimX", c_int),
-                ("stimY", c_int),
-                ("stimHeightOverFloor", c_int),
-                ("redHeightOverFloor", c_int),
-                ("redStimDist", c_int),
-                ("redInclAngle", c_int),
-                ("redStimDistHeigh", c_int),
-                ("redStimDistDepth", c_int)]
+    _fields_ = [('redGeometry', c_int),
+                ('monitorSize', c_int),
+                ('setupName', c_char * 256),
+                ('stimX', c_int),
+                ('stimY', c_int),
+                ('stimHeightOverFloor', c_int),
+                ('redHeightOverFloor', c_int),
+                ('redStimDist', c_int),
+                ('redInclAngle', c_int),
+                ('redStimDistHeigh', c_int),
+                ('redStimDistDepth', c_int)]
 
 #===========================
 #		Loading iViewX.dll 
@@ -151,7 +151,7 @@ else:
 #===========================
 
 systemData = CSystem(0, 0, 0, 0, 0, 0, 0, 0)
-calibrationData = CCalibration(5, 1, 0, 0, 1, 20, 239, 1, 15, b"")
+calibrationData = CCalibration(5, 1, 0, 0, 1, 20, 239, 1, 15, b'')
 leftEye = CEye(0,0,0)
 rightEye = CEye(0,0,0)
 sampleData = CSample(0,leftEye,rightEye,0)
@@ -164,6 +164,6 @@ leftEyePosition = CEyePosition(0, 0, 0, 0, 0, 0, 0)
 rightEyePosition = CEyePosition(0, 0, 0, 0, 0, 0, 0)
 binocularEyePosition = CEyePosition(0, 0, 0, 0, 0, 0, 0)
 trackingStatus = CTrackingStatus(0, leftEyePosition, rightEyePosition, binocularEyePosition)
-redGeometry = CREDGeometry(0, 0, b"", 0, 0, 0, 0, 0, 0, 0, 0)
+redGeometry = CREDGeometry(0, 0, b'', 0, 0, 0, 0, 0, 0, 0, 0)
 
 

--- a/py_smite/iViewXAPIReturnCodes.py
+++ b/py_smite/iViewXAPIReturnCodes.py
@@ -34,103 +34,103 @@ def HandleError(ret):
         return
     elif ret == 2:
         pass
-        #msg = "no new data available"
+        #msg = 'no new data available'
     elif ret == 3:
-        msg = "calibration or validation was aborted during progress"
+        msg = 'calibration or validation was aborted during progress'
     elif ret == 4:
-        msg = "server is running"
+        msg = 'server is running'
     elif ret == 5:
-        msg = "calibration is not in progress"
+        msg = 'calibration is not in progress'
     elif ret == 11:
-        msg = "window is open"        
+        msg = 'window is open'        
     elif ret == 12:
-        msg = "window is closed"        
+        msg = 'window is closed'        
     elif ret == 100:
-        msg = "failed to establish connection"        
+        msg = 'failed to establish connection'        
     elif ret == 101:
-        msg = "no connection established"
+        msg = 'no connection established'
     elif ret == 102:
-        msg = "system is not calibrated"
+        msg = 'system is not calibrated'
     elif ret == 103:
-        msg = "system is not validated"
+        msg = 'system is not validated'
     elif ret == 104:
-        msg = "no eye tracking application running"
+        msg = 'no eye tracking application running'
     elif ret == 105:
-        msg = "failed to establish connection"
+        msg = 'failed to establish connection'
     elif ret == 111:
-        msg = "no connection established"        
+        msg = 'no connection established'        
     elif ret == 112:
-        msg = "parameter out of range"
+        msg = 'parameter out of range'
     elif ret == 113:
-        msg = "eye tracking device required for this calibration method is not connected"
+        msg = 'eye tracking device required for this calibration method is not connected'
     elif ret == 114:
-        msg = "calibration timeout occurred"
+        msg = 'calibration timeout occurred'
     elif ret == 115:
-        msg = "eye tracking is not stable"
+        msg = 'eye tracking is not stable'
     elif ret == 116:
-        msg = "insufficient buffer size"
+        msg = 'insufficient buffer size'
     elif ret == 121:
-        msg = "cannot create socket"
+        msg = 'cannot create socket'
     elif ret == 122:
-        msg = "cannot connect with socket"        
+        msg = 'cannot connect with socket'        
     elif ret == 123:
-        msg = "the defined port is blocked"
+        msg = 'the defined port is blocked'
     elif ret == 124:
-        msg = "failed to delete sockets"
+        msg = 'failed to delete sockets'
     elif ret == 131:
-        msg = "iView X (eyetracking-server) application was not able to response to current request"
+        msg = 'iView X (eyetracking-server) application was not able to response to current request'
     elif ret == 132:
-        msg = "invalid version of iView X (eyetracking-server)"
+        msg = 'invalid version of iView X (eyetracking-server)'
     elif ret == 133:
-        msg = "wrong version of iView X (eyetracking-server) application"
+        msg = 'wrong version of iView X (eyetracking-server) application'
     elif ret == 171:
-        msg = "failed to access log file"
+        msg = 'failed to access log file'
     elif ret == 181:
-        msg = "socket connection failed"
+        msg = 'socket connection failed'
     elif ret == 201:
-        msg = "Could not establish connection. Check if Eye Tracker is installed and running."
+        msg = 'Could not establish connection. Check if Eye Tracker is installed and running.'
     elif ret == 191:
-        msg = "recording buffer is empty"
+        msg = 'recording buffer is empty'
     elif ret == 192:
-        msg = "recording is activated"
+        msg = 'recording is activated'
     elif ret == 193:
-        msg = "data buffer is full"
+        msg = 'data buffer is full'
     elif ret == 194:
-        msg = "iView X (eyetracking-server) application is not ready to record buffer"
+        msg = 'iView X (eyetracking-server) application is not ready to record buffer'
     elif ret == 195:
-        msg = "paused data buffer"
+        msg = 'paused data buffer'
     elif ret == 201:
-        msg = "iView X (eyetracking-server) application was not found"
+        msg = 'iView X (eyetracking-server) application was not found'
     elif ret == 202:
-        msg = "path for file does not exist"
+        msg = 'path for file does not exist'
     elif ret == 203:
-        msg = "access denied"
+        msg = 'access denied'
     elif ret == 204:
-        msg = "access incomplete"
+        msg = 'access incomplete'
     elif ret == 205:
-        msg = "out of memory"
+        msg = 'out of memory'
     elif ret == 211:
-        msg = "failed to access eye tracking device"
+        msg = 'failed to access eye tracking device'
     elif ret == 212:
-        msg = "failed to access eye tracking device"
+        msg = 'failed to access eye tracking device'
     elif ret == 213:
-        msg = "failed to access port connected to eye tracking device"
+        msg = 'failed to access port connected to eye tracking device'
     elif ret == 220:
-        msg = "failed to open port"
+        msg = 'failed to open port'
     elif ret == 221:
-        msg = "failed to close port"
+        msg = 'failed to close port'
     elif ret == 222:
-        msg = "failed to access AOI data"
+        msg = 'failed to access AOI data'
     elif ret == 223:
-        msg = "AOI not defined"
+        msg = 'AOI not defined'
     elif ret == 250:
-        msg = "failed to access requested feature"
+        msg = 'failed to access requested feature'
     elif ret == 300:
-        msg = "function is deprecated"
+        msg = 'function is deprecated'
     elif ret == 400:
-        msg = "function or dll not initialized"
+        msg = 'function or dll not initialized'
     else:
-        msg = "Unknown return Code " + str(ret)
+        msg = 'Unknown return Code ' + str(ret)
         
     if ret != 2:
         print(msg)

--- a/py_smite/version.py
+++ b/py_smite/version.py
@@ -1,13 +1,13 @@
-__version__ = "1.0.2"
+__version__ = '1.0.2'
 
-__title__ = "py_smite"
-__description__ = "SMITE is a toolbox for using eye trackers from SMI with Python, specifically offering integration with PsychoPy."
-__url__ = "https://github.com/marcus-nystrom/SMITE"
+__title__ = 'py_smite'
+__description__ = 'SMITE is a toolbox for using eye trackers from SMI with Python, specifically offering integration with PsychoPy.'
+__url__ = 'https://github.com/marcus-nystrom/SMITE'
 __uri__ = __url__
-__doc__ = __description__ + " <" + __url__ + ">"
+__doc__ = __description__ + ' <' + __url__ + '>'
 
-__author__ = "Marcus Nystrom"
-__email__ = "marcus.nystrom@humlab.lu.se"
+__author__ = 'Marcus Nystrom'
+__email__ = 'marcus.nystrom@humlab.lu.se'
 
-__license__ = "Creative Commons Attribution 4.0 (CC BY 4.0)"
-__copyright__ = "Copyright (c) 2019-2023 " + __author__
+__license__ = 'Creative Commons Attribution 4.0 (CC BY 4.0)'
+__copyright__ = 'Copyright (c) 2019-2023 ' + __author__

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ setup(
     long_description_content_type = 'text/markdown',
     url=main_ns['__url__'],
     project_urls={
-        "Source Code": main_ns['__url__'],
+        'Source Code': main_ns['__url__'],
     },
     license=main_ns['__license__'],
 


### PR DESCRIPTION
Generated by running the following command from SMITE/:

find . -type f -name '*.py' | xargs -I X sed -i "s/\"/'/g" X

In addition to this I made a few manual changes:
- Removal of an extraneous quote in helpers.py, line 255.
- Removed changes to copied license text.
- Removed changes in calls to subprocess.Popen().
- Removed changes that would conflict with existing PRs (in iViewXAPI.py, lines 142--145).

(Nitpick mentioned in https://github.com/marcus-nystrom/SMITE/issues/2.)